### PR TITLE
[BE] 投稿にいいねできるようにしました

### DIFF
--- a/backend/src/application/post/dto/likePost.dto.ts
+++ b/backend/src/application/post/dto/likePost.dto.ts
@@ -1,0 +1,9 @@
+export class LikePostRequestDto {
+  userId: string;
+  postId: string;
+
+  constructor(postId: string, userId: string) {
+    this.userId = userId;
+    this.postId = postId;
+  }
+}

--- a/backend/src/application/post/service/postLike.service.ts
+++ b/backend/src/application/post/service/postLike.service.ts
@@ -1,3 +1,4 @@
+import { Like } from "../../../domain/post/entity/like.entity";
 import { IPostRepository } from "../../../domain/post/repository/post.repository";
 import { PostId } from "../../../domain/post/value_object";
 import { UserId } from "../../../domain/user/value_object";
@@ -7,15 +8,26 @@ import { LikePostRequestDto } from "../dto/likePost.dto";
 export class PostLikeService {
   constructor(private postRepository: IPostRepository) { }
 
-  async likePost(likePostRequestDto: LikePostRequestDto): Promise<void> {
+  async toggleLike(likePostRequestDto: LikePostRequestDto): Promise<void> {
     const userId = new UserId(likePostRequestDto.userId);
     const postId = new PostId(likePostRequestDto.postId);
-    const isExistsPostLike = await this.postRepository.isExistsPostLikeByUserIdAndPostId(userId, postId);
+    const like = new Like(userId, postId);
+    const existsLike = await this.postRepository.existsLikeByUserAndPost(like);
 
-    if (isExistsPostLike) {
-      await this.postRepository.unlike(userId, postId);
+    if (existsLike) {
+      await this.unlike(like);
     } else {
-      await this.postRepository.like(userId, postId);
+      await this.like(like);
     }
   }
+
+  private async unlike(existingLike: Like): Promise<void> {
+    await this.postRepository.deleteLike(existingLike);
+  }
+
+  private async like(newLike: Like): Promise<void> {
+    await this.postRepository.createLike(newLike);
+
+  }
+
 }

--- a/backend/src/application/post/service/postLike.service.ts
+++ b/backend/src/application/post/service/postLike.service.ts
@@ -1,11 +1,11 @@
+import { IPostRepository } from "../../../domain/post/repository/post.repository";
 import { PostId } from "../../../domain/post/value_object";
 import { UserId } from "../../../domain/user/value_object";
-import { PostRepository } from "../../../infrastructure/repository/post.repository";
 import { LikePostRequestDto } from "../dto/likePost.dto";
 
 
 export class PostLikeService {
-  constructor(private postRepository: PostRepository) { }
+  constructor(private postRepository: IPostRepository) { }
 
   async likePost(likePostRequestDto: LikePostRequestDto): Promise<void> {
     const userId = new UserId(likePostRequestDto.userId);

--- a/backend/src/application/post/service/postLike.service.ts
+++ b/backend/src/application/post/service/postLike.service.ts
@@ -1,0 +1,21 @@
+import { PostId } from "../../../domain/post/value_object";
+import { UserId } from "../../../domain/user/value_object";
+import { PostRepository } from "../../../infrastructure/repository/post.repository";
+import { LikePostRequestDto } from "../dto/likePost.dto";
+
+
+export class PostLikeService {
+  constructor(private postRepository: PostRepository) { }
+
+  async likePost(likePostRequestDto: LikePostRequestDto): Promise<void> {
+    const userId = new UserId(likePostRequestDto.userId);
+    const postId = new PostId(likePostRequestDto.postId);
+    const isExistsPostLike = await this.postRepository.isExistsPostLikeByUserIdAndPostId(userId, postId);
+
+    if (isExistsPostLike) {
+      await this.postRepository.unLike(userId, postId);
+    } else {
+      await this.postRepository.like(userId, postId);
+    }
+  }
+}

--- a/backend/src/application/post/service/postLike.service.ts
+++ b/backend/src/application/post/service/postLike.service.ts
@@ -27,7 +27,6 @@ export class PostLikeService {
 
   private async like(newLike: Like): Promise<void> {
     await this.postRepository.createLike(newLike);
-
   }
 
 }

--- a/backend/src/application/post/service/postLike.service.ts
+++ b/backend/src/application/post/service/postLike.service.ts
@@ -13,7 +13,7 @@ export class PostLikeService {
     const isExistsPostLike = await this.postRepository.isExistsPostLikeByUserIdAndPostId(userId, postId);
 
     if (isExistsPostLike) {
-      await this.postRepository.unLike(userId, postId);
+      await this.postRepository.unlike(userId, postId);
     } else {
       await this.postRepository.like(userId, postId);
     }

--- a/backend/src/application/post/test/postLike.service.test.ts
+++ b/backend/src/application/post/test/postLike.service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { PostLikeService } from "../service/postLike.service";
 import { PostFakeRepository } from '../../../infrastructure/repository/post.fakeRepository';
 import { LikePostRequestDto } from "../dto/likePost.dto";
@@ -10,20 +10,30 @@ describe('PostLikeService', () => {
   const postFakeRepository = new PostFakeRepository()
   const postLikeService = new PostLikeService(postFakeRepository);
 
-
   it('投稿にいいねすることができること', async () => {
     // given
-    postFakeRepository.isExistsPostLikeByUserIdAndPostId = vi.fn().mockResolvedValue(false);
+    const createLikeSpy = vi.spyOn(postFakeRepository, 'createLike')
+    postFakeRepository.existsLikeByUserAndPost = vi.fn().mockResolvedValue(false);
     const likePostRequestDto = new LikePostRequestDto(PostId.generate().value, UserId.generate().value);
-    // when & then
-    await postLikeService.likePost(likePostRequestDto);
+
+    // when
+    await postLikeService.toggleLike(likePostRequestDto);
+
+    // then
+    expect(createLikeSpy).toHaveBeenCalled();
+
   });
 
   it('投稿のいいねを外すことができること', async () => {
     // given
-    postFakeRepository.isExistsPostLikeByUserIdAndPostId = vi.fn().mockResolvedValue(true);
+    const deleteLikeSpy = vi.spyOn(postFakeRepository, 'deleteLike')
+    postFakeRepository.existsLikeByUserAndPost = vi.fn().mockResolvedValue(true);
     const likePostRequestDto = new LikePostRequestDto(PostId.generate().value, UserId.generate().value);
-    // when & then
-    await postLikeService.likePost(likePostRequestDto);
+
+    // when
+    await postLikeService.toggleLike(likePostRequestDto);
+
+    // then
+    expect(deleteLikeSpy).toHaveBeenCalled();
   });
 });

--- a/backend/src/application/post/test/postLike.service.test.ts
+++ b/backend/src/application/post/test/postLike.service.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, vi } from "vitest";
+import { PostLikeService } from "../service/postLike.service";
+import { PostFakeRepository } from '../../../infrastructure/repository/post.fakeRepository';
+import { LikePostRequestDto } from "../dto/likePost.dto";
+import { PostId } from "../../../domain/post/value_object";
+import { UserId } from "../../../domain/user/value_object";
+
+
+describe('PostLikeService', () => {
+  const postFakeRepository = new PostFakeRepository()
+  const postLikeService = new PostLikeService(postFakeRepository);
+
+
+  it('投稿にいいねすることができること', async () => {
+    // given
+    postFakeRepository.isExistsPostLikeByUserIdAndPostId = vi.fn().mockResolvedValue(false);
+    const likePostRequestDto = new LikePostRequestDto(PostId.generate().value, UserId.generate().value);
+    // when & then
+    await postLikeService.likePost(likePostRequestDto);
+  });
+
+  it('投稿のいいねを外すことができること', async () => {
+    // given
+    postFakeRepository.isExistsPostLikeByUserIdAndPostId = vi.fn().mockResolvedValue(true);
+    const likePostRequestDto = new LikePostRequestDto(PostId.generate().value, UserId.generate().value);
+    // when & then
+    await postLikeService.likePost(likePostRequestDto);
+  });
+});

--- a/backend/src/application/post/test/postLike.service.test.ts
+++ b/backend/src/application/post/test/postLike.service.test.ts
@@ -21,7 +21,6 @@ describe('PostLikeService', () => {
 
     // then
     expect(createLikeSpy).toHaveBeenCalled();
-
   });
 
   it('投稿のいいねを外すことができること', async () => {

--- a/backend/src/domain/post/entity/like.entity.ts
+++ b/backend/src/domain/post/entity/like.entity.ts
@@ -1,0 +1,35 @@
+import { UserId } from "../../user/value_object";
+import { PostId } from "../value_object";
+
+export class Like {
+  private readonly userId: UserId;
+  private readonly postId: PostId;
+
+  constructor(
+    userId: UserId,
+    postId: PostId,
+  ) {
+    this.userId = userId;
+    this.postId = postId;
+  }
+
+  // 永続化層から取得したデータをエンティティに変換する際に使用
+  public static reConstruct(
+    userId: string,
+    postId: string,
+  ): Like {
+    return new Like(
+      new UserId(userId),
+      new PostId(postId),
+    );
+  }
+
+  // getter
+  public getPostId(): PostId {
+    return this.postId;
+  }
+
+  public getUserId(): UserId {
+    return this.userId;
+  }
+}

--- a/backend/src/domain/post/repository/post.repository.ts
+++ b/backend/src/domain/post/repository/post.repository.ts
@@ -1,5 +1,11 @@
+import { UserId } from "../../user/value_object";
 import { Post } from "../entity/post.entity";
+import { PostId } from "../value_object";
 
 export interface IPostRepository {
+  create(post: Post): Promise<Post>;
   findAll(): Promise<Post[]>;
+  isExistsPostLikeByUserIdAndPostId(userId: UserId, postId: PostId): Promise<boolean>;
+  like(userId: UserId, postId: PostId): Promise<void>;
+  unLike(userId: UserId, postId: PostId): Promise<void>;
 }

--- a/backend/src/domain/post/repository/post.repository.ts
+++ b/backend/src/domain/post/repository/post.repository.ts
@@ -7,5 +7,5 @@ export interface IPostRepository {
   findAll(): Promise<Post[]>;
   isExistsPostLikeByUserIdAndPostId(userId: UserId, postId: PostId): Promise<boolean>;
   like(userId: UserId, postId: PostId): Promise<void>;
-  unLike(userId: UserId, postId: PostId): Promise<void>;
+  unlike(userId: UserId, postId: PostId): Promise<void>;
 }

--- a/backend/src/domain/post/repository/post.repository.ts
+++ b/backend/src/domain/post/repository/post.repository.ts
@@ -1,11 +1,12 @@
 import { UserId } from "../../user/value_object";
+import { Like } from "../entity/like.entity";
 import { Post } from "../entity/post.entity";
 import { PostId } from "../value_object";
 
 export interface IPostRepository {
   create(post: Post): Promise<Post>;
   findAll(): Promise<Post[]>;
-  isExistsPostLikeByUserIdAndPostId(userId: UserId, postId: PostId): Promise<boolean>;
-  like(userId: UserId, postId: PostId): Promise<void>;
-  unlike(userId: UserId, postId: PostId): Promise<void>;
+  existsLikeByUserAndPost(like: Like): Promise<boolean>;
+  createLike(existingLike: Like): Promise<void>;
+  deleteLike(newLike: Like): Promise<void>;
 }

--- a/backend/src/domain/post/test/entity/like.entity.test.ts
+++ b/backend/src/domain/post/test/entity/like.entity.test.ts
@@ -29,6 +29,4 @@ describe('LikeEntity', () => {
     expect(like.getUserId().value).toBe(userIdValue);
     expect(like.getPostId().value).toBe(postIdValue);
   });
-
-
 })

--- a/backend/src/domain/post/test/entity/like.entity.test.ts
+++ b/backend/src/domain/post/test/entity/like.entity.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { PostId } from "../../value_object";
+import { UserId } from "../../../user/value_object";
+import { Like } from "../../entity/like.entity";
+
+describe('LikeEntity', () => {
+  it('インスタンス生成できること', () => {
+    // given
+    const userId = UserId.generate();
+    const postId = PostId.generate();
+
+    // when
+    const like = new Like(userId, postId);
+
+    // then
+    expect(like.getUserId().value).toBe(userId.value);
+    expect(like.getPostId().value).toBe(postId.value);
+  });
+
+  it('永続化層から取得したデータをエンティティに変換できること', () => {
+    // given
+    const postIdValue = '1234-5678-9012';
+    const userIdValue = '1234-5678-9012';
+
+    // when
+    const like = Like.reConstruct(userIdValue, postIdValue);
+
+    // then
+    expect(like.getUserId().value).toBe(userIdValue);
+    expect(like.getPostId().value).toBe(postIdValue);
+  });
+
+
+})

--- a/backend/src/infrastructure/repository/post.fakeRepository.ts
+++ b/backend/src/infrastructure/repository/post.fakeRepository.ts
@@ -1,3 +1,4 @@
+import { Like } from "../../domain/post/entity/like.entity";
 import { Post } from "../../domain/post/entity/post.entity";
 import { IPostRepository } from "../../domain/post/repository/post.repository";
 import { PostId, Price, Title } from "../../domain/post/value_object";
@@ -40,15 +41,15 @@ export class PostFakeRepository implements IPostRepository {
   }
 
 
-  async isExistsPostLikeByUserIdAndPostId(userId: UserId, postId: PostId): Promise<boolean> {
+  async existsLikeByUserAndPost(like: Like): Promise<boolean> {
     return true
   }
 
-  async like(userId: UserId, postId: PostId): Promise<void> {
+  async createLike(newLike: Like): Promise<void> {
     return
   }
 
-  async unlike(userId: UserId, postId: PostId): Promise<void> {
+  async deleteLike(existingLike: Like): Promise<void> {
     return
   }
 }

--- a/backend/src/infrastructure/repository/post.fakeRepository.ts
+++ b/backend/src/infrastructure/repository/post.fakeRepository.ts
@@ -1,0 +1,54 @@
+import { Post } from "../../domain/post/entity/post.entity";
+import { IPostRepository } from "../../domain/post/repository/post.repository";
+import { PostId, Price, Title } from "../../domain/post/value_object";
+import { UserId } from "../../domain/user/value_object";
+
+
+export class PostFakeRepository implements IPostRepository {
+
+  async create(post: Post): Promise<Post> {
+    const postId = post.getPostId().value;
+    const title = post.getTitle().value;
+    const price = post.getPrice().value;
+    const userId = post.getUserId().value
+    const createAt = post.getCreateAt();
+    const updatedAt = post.getUpdatedAt();
+
+    return Post.reConstruct(postId, title, price, userId, createAt, updatedAt);
+  }
+
+  async findAll(): Promise<Post[]> {
+    const posts: Post[] = [
+      new Post(
+        PostId.generate(),
+        new Title('Post 1'),
+        new Price(1000),
+        UserId.generate(),
+        new Date(),
+        new Date()
+      ),
+      new Post(
+        PostId.generate(),
+        new Title('Post 2'),
+        new Price(2000),
+        UserId.generate(),
+        new Date(),
+        new Date()
+      ),
+    ];
+    return posts;
+  }
+
+
+  async isExistsPostLikeByUserIdAndPostId(userId: UserId, postId: PostId): Promise<boolean> {
+    return true
+  }
+
+  async like(userId: UserId, postId: PostId): Promise<void> {
+    return
+  }
+
+  async unlike(userId: UserId, postId: PostId): Promise<void> {
+    return
+  }
+}

--- a/backend/src/infrastructure/repository/post.repository.ts
+++ b/backend/src/infrastructure/repository/post.repository.ts
@@ -3,6 +3,8 @@ import { Post } from "../../domain/post/entity/post.entity";
 import { prisma } from "../prisma/prisma";
 import { Prisma, PrismaClient } from "@prisma/client";
 import { transactionContext } from "../prisma/transactionContext";
+import { UserId } from "../../domain/user/value_object";
+import { PostId } from "../../domain/post/value_object";
 
 
 export class PostRepository implements IPostRepository {
@@ -32,6 +34,40 @@ export class PostRepository implements IPostRepository {
 
     return posts.map(post => {
       return Post.reConstruct(post.id, post.title, post.price, post.userId, post.createAt, post.updatedAt);
+    });
+  }
+
+  async isExistsPostLikeByUserIdAndPostId(userId: UserId, postId: PostId): Promise<boolean> {
+    const client = this.getClient();
+    const postLike = await client.postLike.findFirst({
+      where: {
+        userId: userId.value,
+        postId: postId.value,
+      }
+    });
+
+    return !!postLike;
+  }
+
+  async like(userId: UserId, postId: PostId): Promise<void> {
+    const client = this.getClient();
+    await client.postLike.create({
+      data: {
+        userId: userId.value,
+        postId: postId.value,
+      }
+    });
+  }
+
+  async unLike(userId: UserId, postId: PostId): Promise<void> {
+    const client = this.getClient();
+    await client.postLike.delete({
+      where: {
+        postId_userId: {
+          userId: userId.value,
+          postId: postId.value,
+        }
+      }
     });
   }
 }

--- a/backend/src/infrastructure/repository/post.repository.ts
+++ b/backend/src/infrastructure/repository/post.repository.ts
@@ -3,8 +3,7 @@ import { Post } from "../../domain/post/entity/post.entity";
 import { prisma } from "../prisma/prisma";
 import { Prisma, PrismaClient } from "@prisma/client";
 import { transactionContext } from "../prisma/transactionContext";
-import { UserId } from "../../domain/user/value_object";
-import { PostId } from "../../domain/post/value_object";
+import { Like } from "../../domain/post/entity/like.entity";
 
 
 export class PostRepository implements IPostRepository {
@@ -37,35 +36,35 @@ export class PostRepository implements IPostRepository {
     });
   }
 
-  async isExistsPostLikeByUserIdAndPostId(userId: UserId, postId: PostId): Promise<boolean> {
+  async existsLikeByUserAndPost(like: Like): Promise<boolean> {
     const client = this.getClient();
     const postLike = await client.postLike.findFirst({
       where: {
-        userId: userId.value,
-        postId: postId.value,
+        userId: like.getUserId().value,
+        postId: like.getPostId().value,
       }
     });
 
     return !!postLike;
   }
 
-  async like(userId: UserId, postId: PostId): Promise<void> {
+  async createLike(newLike: Like): Promise<void> {
     const client = this.getClient();
     await client.postLike.create({
       data: {
-        userId: userId.value,
-        postId: postId.value,
+        userId: newLike.getUserId().value,
+        postId: newLike.getPostId().value,
       }
     });
   }
 
-  async unlike(userId: UserId, postId: PostId): Promise<void> {
+  async deleteLike(existingLike: Like): Promise<void> {
     const client = this.getClient();
     await client.postLike.delete({
       where: {
         postId_userId: {
-          userId: userId.value,
-          postId: postId.value,
+          userId: existingLike.getUserId().value,
+          postId: existingLike.getPostId().value,
         }
       }
     });

--- a/backend/src/infrastructure/repository/post.repository.ts
+++ b/backend/src/infrastructure/repository/post.repository.ts
@@ -59,7 +59,7 @@ export class PostRepository implements IPostRepository {
     });
   }
 
-  async unLike(userId: UserId, postId: PostId): Promise<void> {
+  async unlike(userId: UserId, postId: PostId): Promise<void> {
     const client = this.getClient();
     await client.postLike.delete({
       where: {

--- a/backend/src/infrastructure/repository/test/post.repository.test.ts
+++ b/backend/src/infrastructure/repository/test/post.repository.test.ts
@@ -72,4 +72,92 @@ describe('PostRepository', async () => {
     expect(result2.getPrice().value).toBe(price2.value);
     expect(result2.getUserId().value).toBe(userId2.value);
   }));
+
+  it('ある投稿への同一ユーザーのいいねがある場合、Trueが返ってくること', transactionTest(async () => {
+    // given
+    await userRepository.create(user);
+
+    const postId = PostId.generate();
+    const title = new Title('title');
+    const price = new Price(1000);
+    const userId = user.getUserId();
+    const createAt = new Date();
+    const updatedAt = new Date();
+    const post = new Post(postId, title, price, userId, createAt, updatedAt);
+
+    await postRepository.create(post);
+    await postRepository.like(userId, postId);
+
+    // when
+    const result = await postRepository.isExistsPostLikeByUserIdAndPostId(userId, postId);
+
+    // then
+    expect(result).toBeTruthy();
+  }));
+
+  it('ユーザーが投稿にいいねしていない場合、Falseが返ってくること', transactionTest(async () => {
+    // given
+    await userRepository.create(user);
+
+    const postId = PostId.generate();
+    const title = new Title('title');
+    const price = new Price(1000);
+    const userId = user.getUserId();
+    const createAt = new Date();
+    const updatedAt = new Date();
+    const post = new Post(postId, title, price, userId, createAt, updatedAt);
+
+    await postRepository.create(post);
+
+    // when
+    const result = await postRepository.isExistsPostLikeByUserIdAndPostId(userId, postId);
+
+    // then
+    expect(result).toBeFalsy();
+  }));
+
+  it('投稿にいいねをすることができること', transactionTest(async () => {
+    // given
+    await userRepository.create(user);
+
+    const postId = PostId.generate();
+    const title = new Title('title');
+    const price = new Price(1000);
+    const userId = user.getUserId();
+    const createAt = new Date();
+    const updatedAt = new Date();
+    const post = new Post(postId, title, price, userId, createAt, updatedAt);
+
+    await postRepository.create(post);
+
+    // when
+    await postRepository.like(userId, postId);
+
+    // then
+    const result = await postRepository.isExistsPostLikeByUserIdAndPostId(userId, postId);
+    expect(result).toBeTruthy();
+  }));
+
+  it('投稿へのいいねを外すことができること', transactionTest(async () => {
+    // given
+    await userRepository.create(user);
+
+    const postId = PostId.generate();
+    const title = new Title('title');
+    const price = new Price(1000);
+    const userId = user.getUserId();
+    const createAt = new Date();
+    const updatedAt = new Date();
+    const post = new Post(postId, title, price, userId, createAt, updatedAt);
+
+    await postRepository.create(post);
+    await postRepository.like(userId, postId);
+
+    // when
+    await postRepository.unlike(userId, postId);
+
+    // then
+    const result = await postRepository.isExistsPostLikeByUserIdAndPostId(userId, postId);
+    expect(result).toBeFalsy();
+  }));
 });

--- a/backend/src/infrastructure/repository/test/post.repository.test.ts
+++ b/backend/src/infrastructure/repository/test/post.repository.test.ts
@@ -15,13 +15,21 @@ describe('PostRepository', async () => {
   const postRepository = new PostRepository()
   const userRepository = new UserRepository()
 
+  const salt = await bcrypt.genSalt(10);
+
   const userId = UserId.generate().value;
   const username = 'username';
   const email = 'aaa@aaa.com'
   const RawPassword = 'password';
-  const salt = await bcrypt.genSalt(10);
   const hashedPassword = await bcrypt.hash(RawPassword, salt);
   const user = User.reConstruct(userId, username, email, hashedPassword);
+
+  const userId2 = UserId.generate().value;
+  const username2 = 'username2';
+  const email2 = 'bbb@bbb.com'
+  const RawPassword2 = 'password';
+  const hashedPassword2 = await bcrypt.hash(RawPassword2, salt);
+  const user2 = User.reConstruct(userId2, username2, email2, hashedPassword2);
 
   afterEach(async () => {
     const deletePosts = prisma.post.deleteMany()
@@ -119,6 +127,7 @@ describe('PostRepository', async () => {
   it('投稿にいいねをすることができること', transactionTest(async () => {
     // given
     await userRepository.create(user);
+    await userRepository.create(user2);
 
     const postId = PostId.generate();
     const title = new Title('title');
@@ -128,19 +137,32 @@ describe('PostRepository', async () => {
     const updatedAt = new Date();
     const post = new Post(postId, title, price, userId, createAt, updatedAt);
 
+    const postId2 = PostId.generate();
+    const title2 = new Title('title2');
+    const price2 = new Price(2000);
+    const userId2 = user2.getUserId();
+    const createAt2 = new Date();
+    const updatedAt2 = new Date();
+    const post2 = new Post(postId2, title2, price2, userId2, createAt2, updatedAt2);
+
     await postRepository.create(post);
+    await postRepository.create(post2);
 
     // when
     await postRepository.like(userId, postId);
+    await postRepository.like(userId, postId2);
 
     // then
     const result = await postRepository.isExistsPostLikeByUserIdAndPostId(userId, postId);
     expect(result).toBeTruthy();
+    const result2 = await postRepository.isExistsPostLikeByUserIdAndPostId(userId, postId2);
+    expect(result2).toBeTruthy();
   }));
 
   it('投稿へのいいねを外すことができること', transactionTest(async () => {
     // given
     await userRepository.create(user);
+    await userRepository.create(user2);
 
     const postId = PostId.generate();
     const title = new Title('title');
@@ -150,14 +172,28 @@ describe('PostRepository', async () => {
     const updatedAt = new Date();
     const post = new Post(postId, title, price, userId, createAt, updatedAt);
 
+    const postId2 = PostId.generate();
+    const title2 = new Title('title2');
+    const price2 = new Price(2000);
+    const userId2 = user2.getUserId();
+    const createAt2 = new Date();
+    const updatedAt2 = new Date();
+    const post2 = new Post(postId2, title2, price2, userId2, createAt2, updatedAt2);
+
     await postRepository.create(post);
+    await postRepository.create(post2);
+
     await postRepository.like(userId, postId);
+    await postRepository.like(userId, postId2);
 
     // when
     await postRepository.unlike(userId, postId);
+    await postRepository.unlike(userId, postId2);
 
     // then
     const result = await postRepository.isExistsPostLikeByUserIdAndPostId(userId, postId);
     expect(result).toBeFalsy();
+    const result2 = await postRepository.isExistsPostLikeByUserIdAndPostId(userId, postId2);
+    expect(result2).toBeFalsy();
   }));
 });

--- a/backend/src/infrastructure/repository/test/post.repository.test.ts
+++ b/backend/src/infrastructure/repository/test/post.repository.test.ts
@@ -9,6 +9,7 @@ import { prisma } from "../../prisma/prisma";
 import { User } from '../../../domain/user/entity/user.entity';
 import { UserRepository } from '../user.repository';
 import { transactionTest } from './transactionTest';
+import { Like } from '../../../domain/post/entity/like.entity';
 
 
 describe('PostRepository', async () => {
@@ -94,10 +95,11 @@ describe('PostRepository', async () => {
     const post = new Post(postId, title, price, userId, createAt, updatedAt);
 
     await postRepository.create(post);
-    await postRepository.like(userId, postId);
+    const like = new Like(userId, postId);
+    await postRepository.createLike(like);
 
     // when
-    const result = await postRepository.isExistsPostLikeByUserIdAndPostId(userId, postId);
+    const result = await postRepository.existsLikeByUserAndPost(like);
 
     // then
     expect(result).toBeTruthy();
@@ -116,9 +118,10 @@ describe('PostRepository', async () => {
     const post = new Post(postId, title, price, userId, createAt, updatedAt);
 
     await postRepository.create(post);
+    const like = new Like(userId, postId);
 
     // when
-    const result = await postRepository.isExistsPostLikeByUserIdAndPostId(userId, postId);
+    const result = await postRepository.existsLikeByUserAndPost(like);
 
     // then
     expect(result).toBeFalsy();
@@ -149,13 +152,15 @@ describe('PostRepository', async () => {
     await postRepository.create(post2);
 
     // when
-    await postRepository.like(userId, postId);
-    await postRepository.like(userId, postId2);
+    const like1 = new Like(userId, postId);
+    await postRepository.createLike(like1);
+    const like2 = new Like(userId, postId2);
+    await postRepository.createLike(like2);
 
     // then
-    const result = await postRepository.isExistsPostLikeByUserIdAndPostId(userId, postId);
+    const result = await postRepository.existsLikeByUserAndPost(like1);
     expect(result).toBeTruthy();
-    const result2 = await postRepository.isExistsPostLikeByUserIdAndPostId(userId, postId2);
+    const result2 = await postRepository.existsLikeByUserAndPost(like2);
     expect(result2).toBeTruthy();
   }));
 
@@ -183,17 +188,19 @@ describe('PostRepository', async () => {
     await postRepository.create(post);
     await postRepository.create(post2);
 
-    await postRepository.like(userId, postId);
-    await postRepository.like(userId, postId2);
+    const like1 = new Like(userId, postId);
+    await postRepository.createLike(like1);
+    const like2 = new Like(userId, postId2);
+    await postRepository.createLike(like2);
 
     // when
-    await postRepository.unlike(userId, postId);
-    await postRepository.unlike(userId, postId2);
+    await postRepository.deleteLike(like1);
+    await postRepository.deleteLike(like2);
 
     // then
-    const result = await postRepository.isExistsPostLikeByUserIdAndPostId(userId, postId);
+    const result = await postRepository.existsLikeByUserAndPost(like1);
     expect(result).toBeFalsy();
-    const result2 = await postRepository.isExistsPostLikeByUserIdAndPostId(userId, postId2);
+    const result2 = await postRepository.existsLikeByUserAndPost(like2);
     expect(result2).toBeFalsy();
   }));
 });

--- a/backend/src/routers/posts.ts
+++ b/backend/src/routers/posts.ts
@@ -6,6 +6,8 @@ import { UserQueryService } from "../application/user/service/userQuery.service"
 import { GetAllPostWithUserService } from "../application/query/service/getAllPostWithUser.service";
 import { requiredAuth } from "./middleware";
 import { HttpStatus } from "../shared/constants/statusCode";
+import { LikePostRequestDto } from "../application/post/dto/likePost.dto";
+import { PostLikeService } from "../application/post/service/postLike.service";
 
 const post = new Hono().basePath("/posts");
 
@@ -21,8 +23,14 @@ post.post("/", (c) => {
   return c.json({ message: "post created" }, HttpStatus.CREATED);
 });
 
-post.post("/likes", (c) => {
-  return c.json({ message: "post liked" }, HttpStatus.OK);
+post.post("/likes", async (c) => {
+  const body = await c.req.json();
+  const { userId, postId } = body;
+  const likePostRequestDto = new LikePostRequestDto(postId, userId);
+  const postRepository = new PostRepository();
+  const postLikeService = new PostLikeService(postRepository)
+  await postLikeService.likePost(likePostRequestDto);
+  return c.json({ message: "" }, HttpStatus.OK);
 });
 
 post.post("/comments", (c) => {

--- a/backend/src/routers/posts.ts
+++ b/backend/src/routers/posts.ts
@@ -27,7 +27,6 @@ post.post("/likes", async (c) => {
   const body = await c.req.json();
   const { userId, postId } = body;
   const likePostRequestDto = new LikePostRequestDto(postId, userId);
-  const postRepository = new PostRepository();
   const postLikeService = new PostLikeService(postRepository)
   await postLikeService.likePost(likePostRequestDto);
   return c.json({ message: "" }, HttpStatus.OK);

--- a/backend/src/routers/posts.ts
+++ b/backend/src/routers/posts.ts
@@ -28,7 +28,7 @@ post.post("/likes", async (c) => {
   const { userId, postId } = body;
   const likePostRequestDto = new LikePostRequestDto(postId, userId);
   const postLikeService = new PostLikeService(postRepository)
-  await postLikeService.likePost(likePostRequestDto);
+  await postLikeService.toggleLike(likePostRequestDto);
   return c.json({ message: "" }, HttpStatus.OK);
 });
 


### PR DESCRIPTION
## 概要
- 投稿にいいね(like)といいねを外す(unlike)をできるようにしました

## 動作確認
- postmanで以下を確認しました
  - APIを実行した時にPostLikeレコードが作成されることを確認しました。
  - もう一度実行するとPostLikeレコードが削除されることを確認しました。

## 変更点
-

## 関連するissue
- https://github.com/users/totot1010/projects/3?pane=issue&itemId=91077672&issue=totot1010%7CJisui%7C47
