### PR TITLE
テストが落ちていたので修正

### DIFF
--- a/frontend/src/feature/posts/components/Like/Like.test.tsx
+++ b/frontend/src/feature/posts/components/Like/Like.test.tsx
@@ -17,7 +17,7 @@ const post: Post = {
 }
 const loginUserId = 'id1';
 
-const LikeSpy = vi.spyOn(toggleLikeModule, 'toggleLike').mockResolvedValue();
+const LikeSpy = vi.spyOn(toggleLikeModule, 'toggleLike').mockResolvedValue({ data: { message: "" }, type: "success" });
 
 vi.mock('@/hooks/use-toast', () => ({
   toast: vi.fn().mockResolvedValue(undefined),
@@ -64,7 +64,7 @@ describe('Like', () => {
   });
 
   it('いいねに失敗した場合、toast関数が呼ばれること', async () => {
-    LikeSpy.mockRejectedValue(new Error('error'));
+    LikeSpy.mockResolvedValue({ type: "error", status: "500" });
 
     render(<Like post={post} loginUserId={loginUserId}/>)
 


### PR DESCRIPTION
## 概要
- `いいねに失敗した場合、toast関数が呼ばれること`テストが落ちていたので修正しました

## 動作確認
![スクリーンショット 2025-01-15 0 45 38](https://github.com/user-attachments/assets/dd9f1f33-ab8b-472c-965d-2684f349bf57)


## 変更点
-

## 関連するissue
-
