### PR TITLE
✅ test: ユーザー作成APIのテストを追加

### DIFF
--- a/backend/src/routers/tests/users.test.ts
+++ b/backend/src/routers/tests/users.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import user from "../users";
+import { transactionTest } from "../../infrastructure/repository/test/transactionTest";
+import { UserRepository } from "../../infrastructure/repository/user.repository";
+import { Email } from "../../domain/user/value_object";
+
+
+describe("users", () => {
+  describe("POST /users", () => {
+    it("ユーザーが作成され、201が返却されること", transactionTest(async () => {
+      const response = await user.request("/users", {
+        method: "POST",
+        body: JSON.stringify({
+          email: "test@example.com",
+          username: "test",
+          password: "password12341234",
+        })
+      });
+
+      expect(response.status).toBe(201);
+      expect(await response.json()).toEqual({
+        userId: expect.any(String),
+        email: "test@example.com",
+        username: "test",
+      });
+
+      const dbUser = await new UserRepository().findByEmail(new Email("test@example.com"));
+      expect(dbUser).not.toBeNull();
+    }));
+  });
+});


### PR DESCRIPTION
## 概要
- 試しにユーザーの作成を作成してみました、問題なく通っています
参考になるのはこちら
- https://hono.dev/docs/guides/testing

<img width="340" alt="image" src="https://github.com/user-attachments/assets/22343067-4144-4e7a-bd27-61923c81c88e" />


## 変更点
-

## 関連するissue
- #109 
