### PR TITLE
ユーザーに紐づいた投稿一覧取得API追加

### DIFF
--- a/backend/src/application/post/service/postQuery.service.ts
+++ b/backend/src/application/post/service/postQuery.service.ts
@@ -6,8 +6,8 @@ import { UserId } from "../../../domain/user/value_object";
 export class PostQueryService {
   constructor(private readonly postRepository: IPostRepository) { }
 
-  async findAll(): Promise<Post[]> {
-    return await this.postRepository.findAll();
+  async findAll(userId: string | undefined): Promise<Post[]> {
+    return await this.postRepository.findAll(userId);
   }
 
   async countByUserIdAndType(userId: string, type: PostCountType): Promise<number> {

--- a/backend/src/application/query/service/getAllPostWithUser.service.ts
+++ b/backend/src/application/query/service/getAllPostWithUser.service.ts
@@ -10,8 +10,8 @@ export class GetAllPostWithUserService {
     private readonly userQueryService: UserQueryService
   ) { }
 
-  public async execute(): Promise<getAllPostWithUserDto[]> {
-    const posts: Post[] = await this.postQueryService.findAll();
+  public async execute(userId: string | undefined): Promise<getAllPostWithUserDto[]> {
+    const posts: Post[] = await this.postQueryService.findAll(userId);
     const users: User[] = await this.userQueryService.findAll();
 
     const result: getAllPostWithUserDto[] = [];

--- a/backend/src/application/query/test/service/getAllPostWithUser.service.test.ts
+++ b/backend/src/application/query/test/service/getAllPostWithUser.service.test.ts
@@ -32,7 +32,7 @@ describe('GetAllPostWithUserService', () => {
       ]);
 
       // when
-      const posts = await getAllPostWithUserService.execute();
+      const posts = await getAllPostWithUserService.execute(undefined);
 
       // then
       expect(posts).toHaveLength(2);

--- a/backend/src/domain/post/repository/post.repository.ts
+++ b/backend/src/domain/post/repository/post.repository.ts
@@ -6,7 +6,7 @@ import { PostCountType } from "../types/postCountType";
 
 export interface IPostRepository {
   create(post: Post): Promise<Post>;
-  findAll(): Promise<Post[]>;
+  findAll(userId: string | undefined): Promise<Post[]>;
   countByUserIdAndType(userId: UserId, type: PostCountType): Promise<number>;
   existsLikeByUserAndPost(like: Like): Promise<boolean>;
   createLike(existingLike: Like): Promise<void>;

--- a/backend/src/infrastructure/repository/post.fakeRepository.ts
+++ b/backend/src/infrastructure/repository/post.fakeRepository.ts
@@ -20,7 +20,7 @@ export class PostFakeRepository implements IPostRepository {
     );
   }
 
-  async findAll(): Promise<Post[]> {
+  async findAll(userId: string | undefined): Promise<Post[]> {
     const post1 = Post.reConstruct('id1', 'title1', 100, 'userId1', new Date(), new Date(), []);
     const post2 = Post.reConstruct('id2', 'title2', 200, 'userId2', new Date(), new Date(), []);
     return [post1, post2];

--- a/backend/src/infrastructure/repository/post.repository.ts
+++ b/backend/src/infrastructure/repository/post.repository.ts
@@ -30,9 +30,14 @@ export class PostRepository implements IPostRepository {
     return Post.reConstruct(id, title, price, userId, createdAt, updatedAt, []);
   }
 
-  async findAll(): Promise<Post[]> {
+  async findAll(userId: string | undefined): Promise<Post[]> {
     const client = this.getClient();
+    const where: Prisma.PostWhereInput = {}
+    if (userId) {
+      where.userId = userId
+    }
     const posts = await client.post.findMany({
+      where,
       include: {
         likes: {
           select: {

--- a/backend/src/infrastructure/repository/test/post.repository.test.ts
+++ b/backend/src/infrastructure/repository/test/post.repository.test.ts
@@ -74,7 +74,7 @@ describe('PostRepository', async () => {
       await postRepository.createLike(new Like(userId, postId2));
 
       // when
-      const results = await postRepository.findAll();
+      const results = await postRepository.findAll(undefined);
       const [result2, result1] = results;
 
       // then
@@ -89,6 +89,47 @@ describe('PostRepository', async () => {
       expect(result2.getPrice().value).toBe(price2.value);
       expect(result2.getUserId().value).toBe(userId2.value);
       expect(result2.getLikes()).toHaveLength(1);
+    }));
+
+    it('ユーザーに紐づいた全ての投稿を取得できること', transactionTest(async () => {
+      // given
+      await userRepository.create(user);
+      await userRepository.create(user2);
+
+      const postId = PostId.generate();
+      const title = new Title('title');
+      const price = new Price(1000);
+      const userId = user.getUserId();
+      const createdAt = new Date();
+      const updatedAt = new Date();
+      const post = new Post(postId, title, price, userId, createdAt, updatedAt, []);
+
+      const postId2 = PostId.generate();
+      const title2 = new Title('title2');
+      const price2 = new Price(2000);
+      const userId2 = user2.getUserId();
+      const createdAt2 = new Date();
+      const updatedAt2 = new Date();
+      const post2 = new Post(postId2, title2, price2, userId2, createdAt2, updatedAt2, []);
+
+      await postRepository.create(post);
+      await postRepository.create(post2);
+
+      await postRepository.createLike(new Like(userId, postId));
+      await postRepository.createLike(new Like(userId2, postId));
+      await postRepository.createLike(new Like(userId, postId2));
+
+      // when
+      const results = await postRepository.findAll(userId.value);
+      const [result] = results;
+
+      // then
+      expect(results).toHaveLength(1);
+      expect(result.getPostId().value).toBe(postId.value);
+      expect(result.getTitle().value).toBe(title.value);
+      expect(result.getPrice().value).toBe(price.value);
+      expect(result.getUserId().value).toBe(userId.value);
+      expect(result.getLikes()).toHaveLength(2);
     }));
   });
 
@@ -276,7 +317,7 @@ describe('PostRepository', async () => {
       await postRepository.createComment(comment);
 
       // then
-      const result = await postRepository.findAll();
+      const result = await postRepository.findAll(undefined);
       expect(result).toHaveLength(1);
       expect(result[0].getComments()).toHaveLength(1);
       expect(result[0].getComments()[0].getCommentId().value).toBe(commentId.value);

--- a/backend/src/routers/posts.ts
+++ b/backend/src/routers/posts.ts
@@ -86,8 +86,9 @@ post.post("/comments", async (c) => {
 
 // みんなの投稿
 post.get("/", async (c) => {
+  const userId: string | undefined = c.req.query('userId')
   const getAllPostWithUserService = new GetAllPostWithUserService(postQueryService, userQueryService);
-  const results = await getAllPostWithUserService.execute();
+  const results = await getAllPostWithUserService.execute(userId);
   return c.json(results, HttpStatus.OK);
 });
 


### PR DESCRIPTION
## 概要
- ユーザーに紐づいた投稿一覧取得API追加しました

## 動作確認
- APIリクエストにuserIDクエリパラメータが付いている場合はそのuserIDに紐づいた投稿が取得できること確認
- userIDクエリパラメータが付いていない場合は全ての投稿を取得できること確認

## 変更点
-

## 関連するissue
-
